### PR TITLE
Add new custom workflow

### DIFF
--- a/.github/workflows/update-gh-pat.yml
+++ b/.github/workflows/update-gh-pat.yml
@@ -1,0 +1,30 @@
+name: Refresh GH_PAT from GitHub App
+
+on:
+  schedule:
+    - cron: '*/55 * * * *'  # Every 55 minutes
+  workflow_dispatch:
+
+jobs:
+  refresh-token:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+      - name: Generate GitHub App token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          installation_id: ${{ secrets.INSTALLATION_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Update GH_PAT secret
+        uses: hmanzur/actions-set-secret@v2.2.0
+        with:
+          name: GH_PAT
+          value: ${{ steps.generate_token.outputs.token }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Aim to update GH_PAT repo secret via GitHub App and custom workflow

this aims to replace the long-lived user token (90-days) with a short-lived app token (1 hour)